### PR TITLE
Fix ssr story

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,8 @@ export default function prepass(
 			// stateless functional components
 			doRender = () => {
 				try {
-					return Promise.resolve(nodeName.call(vnode.__c, props, cctx));
+				  vnode.__c = c = new Component(props, context);
+				  return Promise.resolve(nodeName.call(vnode.__c, props, cctx));
 				}
 				catch (e) {
 					if (e && e.then) {


### PR DESCRIPTION
Try it with this sandbox, you can revert to:

```
try {
  return Promise.resolve(nodeName.call(vnode.__c, props, cctx));
}
```

And see how all of a sudden hooks aren't supported anymore

This also alignes more with how Preact handles things internally