### PR TITLE
Fix traversal of multiple children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { assign, getChildren } from "./util";
-import { options, Fragment, Component, h } from "preact";
+import { options, Fragment, Component } from "preact";
 import { Suspense } from "preact/compat";
 
 const createContextDefaultValue = "__p";
@@ -126,13 +126,13 @@ export default function prepass(
         context = assign(assign({}, context), c.getChildContext());
       }
 
-      let nodeToRender = rendered;
-
-      if (Array.isArray(nodeToRender)) {
-        nodeToRender = h(Fragment, null, rendered);
+      if (Array.isArray(rendered)) {
+        return Promise.all(
+          rendered.map((node) => prepass(node, visitor, context))
+        );
       }
 
-      return prepass(nodeToRender, visitor, context);
+      return prepass(rendered, visitor, context);
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { assign, getChildren } from "./util";
-import { options, Fragment, Component } from "preact";
+import { options, Fragment, Component, h } from "preact";
 import { Suspense } from "preact/compat";
 
 const createContextDefaultValue = "__p";
@@ -126,7 +126,13 @@ export default function prepass(
         context = assign(assign({}, context), c.getChildContext());
       }
 
-      return prepass(rendered, visitor, context);
+      let nodeToRender = rendered;
+
+      if (Array.isArray(nodeToRender)) {
+        nodeToRender = h(Fragment, null, rendered);
+      }
+
+      return prepass(nodeToRender, visitor, context);
     });
   }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -187,16 +187,11 @@ describe("prepass", () => {
       expect(Inner.mock.calls.length).toEqual(1);
     });
 
-    it("should traverse multiple rendered children", async () => {
+    it("should traverse array of nodes returned by render", async () => {
       const Inner = jest.fn(() => <div />);
-      const Outer = jest.fn(({ children }) => children);
+      const Outer = jest.fn(() => [<Inner />, <Inner />]);
 
-      await prepass(
-        <Outer>
-          <Inner />
-          <Inner />
-        </Outer>
-      );
+      await prepass(<Outer />);
 
       expect(Inner.mock.calls.length).toEqual(2);
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -187,6 +187,20 @@ describe("prepass", () => {
       expect(Inner.mock.calls.length).toEqual(1);
     });
 
+    it("should traverse multiple rendered children", async () => {
+      const Inner = jest.fn(() => <div />);
+      const Outer = jest.fn(({ children }) => children);
+
+      await prepass(
+        <Outer>
+          <Inner />
+          <Inner />
+        </Outer>
+      );
+
+      expect(Inner.mock.calls.length).toEqual(2);
+    });
+
     it("should traverse children rendered in nested vnode tree", async () => {
       const Inner = jest.fn(() => <div />);
       const Outer = jest.fn(({ children }) => (


### PR DESCRIPTION
Rendering components with multiple children fails currently, e.g.:

```jsx
<Outer>
	<InnerA />
	<InnerB />
</Outer>
```

This is a valid JSX syntax. I could fix it by replacing array children with a Fragment.