### PR TITLE
Disable rogue state updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,10 @@ export default function prepass(
     // initialize components in dirty state so setState() doesn't enqueue re-rendering:
     c.__d = true;
     c.__v = vnode;
+    /* istanbul ignore else */
+    if (c.state === undefined) {
+      c.state = {};
+    }
 
     // options.render was renamed to _render (mangled to __r)
     if (options.render) options.render(vnode);
@@ -98,6 +102,9 @@ export default function prepass(
       c.__v = vnode;
       c.props = props;
       c.context = context;
+      if (c.state === undefined) {
+        c.state = {};
+      }
 
       // TODO: does react-ssr-prepass call the visitor before lifecycle hooks?
       if (nodeName.getDerivedStateFromProps)
@@ -109,7 +116,7 @@ export default function prepass(
 
       doRender = () => {
         try {
-          return Promise.resolve(c.render(c.props, c.state || {}, c.context));
+          return Promise.resolve(c.render(c.props, c.state, c.context));
         } catch (e) {
           if (e && e.then) {
             return e.then(doRender, doRender);

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,8 @@ export default function prepass(
   ) {
     let doRender /* : () => Promise<void> */;
     let c = (vnode.__c = new Component(props, context));
+    // initialize components in dirty state so setState() doesn't enqueue re-rendering:
+    c.__d = true;
     c.__v = vnode;
 
     // options.render was renamed to _render (mangled to __r)
@@ -91,6 +93,8 @@ export default function prepass(
       // class-based components
       // c = new nodeName(props, context);
       c = vnode.__c = new nodeName(props, context);
+      // initialize components in dirty state so setState() doesn't enqueue re-rendering:
+      c.__d = true;
       c.__v = vnode;
       c.props = props;
       c.context = context;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5648,9 +5648,9 @@ preact-render-to-string@^5.1.10:
     pretty-format "^3.8.0"
 
 preact@10:
-  version "10.5.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.2.tgz#4c07c27f4239666840e0d637ec7c110cfcae181d"
-  integrity sha512-4y2Q6kMiJtMONMJR7z+o8P5tGkMzVItyy77AXGrUdusv+dk4jwoS3KrpCBkFloY2xsScRJYwZQZrx89tTjDkOw==
+  version "10.5.4"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.4.tgz#1e4d148f949fa54656df6c9bc9218bd4e12016e3"
+  integrity sha512-u0LnVtL9WWF61RLzIbEsVFOdsahoTQkQqeRwyf4eWuLMFrxTH/C47tqcnizbUH54E4KG8UzuuZaMc9KarHmpqQ==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This initializes components with the dirty flag set, which prevents them from being pushed into Preact's (DOM) rendering queue. State updates and forceUpdate() will still work, but they won't attempt to re-rendering using preact.